### PR TITLE
Configure global page paramaters with config

### DIFF
--- a/example/gtag_analytics_example.dart
+++ b/example/gtag_analytics_example.dart
@@ -2,12 +2,11 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 import 'package:gtag_analytics/gtag_analytics.dart';
-import 'package:gtag_analytics/src/interop.dart';
 
 void main() {
   final inProduction = const String.fromEnvironment('production') == 'true';
   final ga = new GoogleAnalytics(failSilently: inProduction);
-  ga.config("GA_TRACKING_ID", options: Options(page_path: "/home"));
+  ga.config('GA_TRACKING_ID', pagePath: '/home');
   ga.sendPageView();
   ga.sendCustom('choose_action', category: 'play');
 }

--- a/example/gtag_analytics_example.dart
+++ b/example/gtag_analytics_example.dart
@@ -2,9 +2,12 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 import 'package:gtag_analytics/gtag_analytics.dart';
+import 'package:gtag_analytics/src/interop.dart';
 
 void main() {
   final inProduction = const String.fromEnvironment('production') == 'true';
   final ga = new GoogleAnalytics(failSilently: inProduction);
+  ga.config("GA_TRACKING_ID", options: Options(page_path: "/home"));
+  ga.sendPageView();
   ga.sendCustom('choose_action', category: 'play');
 }

--- a/lib/src/gtag_analytics.dart
+++ b/lib/src/gtag_analytics.dart
@@ -52,6 +52,12 @@ class GoogleAnalytics {
     _sendEvent('page_view', _empty);
   }
 
+  /// Configures GA instance with page parameters
+  void config(measurmentId, {String pagePath, String pageTitle}) {
+    _config(measurmentId,
+        options: Options(page_path: pagePath, page_title: pageTitle));
+  }
+
   /// Send a sign up event, with method (such as 'Facebook', 'email', or
   /// 'Google'.
   void sendSignUp({String method: 'N/A'}) {
@@ -72,7 +78,7 @@ class GoogleAnalytics {
     }
   }
 
-  void config(String measurmentId, {Options options}) {
+  void _config(String measurmentId, {Options options}) {
     try {
       gtag('config', measurmentId, options ?? _empty);
       // ignore: avoid_catching_errors

--- a/lib/src/gtag_analytics.dart
+++ b/lib/src/gtag_analytics.dart
@@ -53,8 +53,8 @@ class GoogleAnalytics {
   }
 
   /// Configures GA instance with page parameters
-  void config(measurmentId, {String pagePath, String pageTitle}) {
-    _config(measurmentId,
+  void config(measurementId, {String pagePath, String pageTitle}) {
+    _config(measurementId,
         options: Options(page_path: pagePath, page_title: pageTitle));
   }
 
@@ -78,9 +78,9 @@ class GoogleAnalytics {
     }
   }
 
-  void _config(String measurmentId, {Options options}) {
+  void _config(String measurementId, {Options options}) {
     try {
-      gtag('config', measurmentId, options ?? _empty);
+      gtag('config', measurementId, options ?? _empty);
       // ignore: avoid_catching_errors
     } on NoSuchMethodError catch (e) {
       if (!failSilently) {

--- a/lib/src/gtag_analytics.dart
+++ b/lib/src/gtag_analytics.dart
@@ -71,4 +71,16 @@ class GoogleAnalytics {
       }
     }
   }
+
+  void config(String measurmentId, {Options options}) {
+    try {
+      gtag('config', measurmentId, options ?? _empty);
+      // ignore: avoid_catching_errors
+    } on NoSuchMethodError catch (e) {
+      if (!failSilently) {
+        throw new StateError('gtag function not found. Please make sure you '
+            'include the Google Analytics script in your HTML. ($e)');
+      }
+    }
+  }
 }

--- a/lib/src/interop.dart
+++ b/lib/src/interop.dart
@@ -17,7 +17,9 @@ class Options {
       int value,
       String method,
       String description,
-      bool fatal});
+      bool fatal,
+      String page_title,
+      String page_path});
 
   external String get description;
 
@@ -36,4 +38,12 @@ class Options {
   external int get value;
 
   external set value(int v);
+
+  external String get page_title;
+
+  external String get page_path;
+
+  external set page_title(String v);
+
+  external set page_path(String v);
 }

--- a/test/gtag_analytics_test.dart
+++ b/test/gtag_analytics_test.dart
@@ -3,6 +3,7 @@
 
 @TestOn('browser')
 import 'package:gtag_analytics/gtag_analytics.dart';
+import 'package:gtag_analytics/src/interop.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -11,6 +12,13 @@ void main() {
 
     setUp(() {
       ga = new GoogleAnalytics();
+    });
+
+    test('config', () {
+      expect(
+          () =>
+              ga.config('GA_TRACKING_ID', options: Options(page_path: '/home')),
+          returnsNormally);
     });
 
     test('send pageview', () {

--- a/test/gtag_analytics_test.dart
+++ b/test/gtag_analytics_test.dart
@@ -15,9 +15,7 @@ void main() {
     });
 
     test('config', () {
-      expect(
-          () =>
-              ga.config('GA_TRACKING_ID', options: Options(page_path: '/home')),
+      expect(() => ga.config('GA_TRACKING_ID', pagePath: '/home'),
           returnsNormally);
     });
 


### PR DESCRIPTION
This change allows setting global page parameters like path and title.

It is needed for SPAs where the path is always "/" and automatic page tracking is not working.

I was following this doc: https://developers.google.com/analytics/devguides/collection/gtagjs/pages

Use:
```
  ga.config('GA_TRACKING_ID', pagePath: '/home');
  ga.sendPageView();
```

Not sure if it is the best API as you have to provide 'GA_TRACKING_ID' each time

I am using it in Flutter Web app.